### PR TITLE
Add client ready for authentication

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,6 @@
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"
+Layout/SpaceBeforeBlockBraces:
+  Exclude:
+    - "**/*_spec.rb"

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "https://rubygems.org"
+source 'https://rubygems.org'
 
 # Specify your gem's dependencies in amadeus.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The client can be initialized directly or via environment variables.
 
 ```ruby
 # Initialize using parameters
-amadeus = Amadeus::Client.new(client_id: '...', client_secret: '...')
+amadeus = Amadeus::Client.new(api_key: '...', api_secret: '...')
 
 # Alternative: Initialize using environment variables
 # * AMADEUS_API_KEY
@@ -60,20 +60,24 @@ __Next__: [Learn more about our initializing the Ruby SDK](https://developer.ama
 The SDK makes it easy to add your own logger.
 
 ```ruby
+require 'logger'
+
 amadeus = Amadeus::Client.new(
-  client_id: '...',
-  client_secret: '...',
-  logger: MyOwnLogger.new
+  api_key: '...',
+  api_secret: '...',
+  logger: Logger.new(STDOUT)
 )
 ```
 
 Additionally, to enable more verbose logging, you can set the appropriate level either via a parameter on initialization, or using the `AMADEUS_LOG_LEVEL` environment variable.
 
 ```ruby
+require 'logger'
+
 amadeus = Amadeus::Client.new(
-  client_id: '...',
-  client_secret: '...',
-  log_level: 1 # defaults to silent, 0
+  api_key: '...',
+  api_secret: '...',
+  log_level: Logger::DEBUG # defaults to Logger::WARN, aka "2"
 )
 ```
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,9 +1,11 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
+RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: %i[rubocop spec]
 
 task :console do
   exec 'irb -r amadeus -I ./lib -r awesome_print'

--- a/amadeus.gemspec
+++ b/amadeus.gemspec
@@ -1,4 +1,4 @@
-# coding: utf-8
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'amadeus/version'
@@ -21,9 +21,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_development_dependency 'awesome_print', '~> 1.8.0'
   spec.add_development_dependency 'bundler', '~> 1.16'
   spec.add_development_dependency 'rake', '~> 12.3'
   spec.add_development_dependency 'rspec', '~> 3.7'
+  spec.add_development_dependency 'rubocop', '~> 0.51.0'
   spec.add_development_dependency 'webmock', '~> 3.1.1'
-  spec.add_development_dependency 'awesome_print', '~> 1.8.0'
 end

--- a/lib/amadeus.rb
+++ b/lib/amadeus.rb
@@ -1,5 +1,2 @@
-require "amadeus/version"
-
-module Amadeus
-  # Your code goes here...
-end
+require 'amadeus/version'
+require 'amadeus/client'

--- a/lib/amadeus/client.rb
+++ b/lib/amadeus/client.rb
@@ -1,0 +1,48 @@
+require 'net/https'
+require 'json'
+require 'logger'
+
+module Amadeus
+  # The Amadeus client library for accessing
+  # the travel APIs.
+  class Client
+    attr_reader :api_key, :api_secret, :logger
+
+    # Initialize using your credentials:
+    #
+    #   amadeus = Amadeus::Client.new(
+    #     api_key:    'YOUR_API_KEY',
+    #     api_secret: 'YOUR_API_SECRET'
+    #   )
+    #
+    # Alternatively, initialize the library using
+    # the environment variables +AMADEUS_API_KEY+
+    # and +AMADEUS_API_SECRET+
+    #
+    #   amadeus = Amadeus::Client.new
+    def initialize(options = {})
+      @api_key = initialize_required(:api_key, options)
+      @api_secret = initialize_required(:api_secret, options)
+      @logger = initialize_logger(options)
+      @logger.level = initialize_optional(:log_level, options, Logger::WARN)
+    end
+
+    private
+
+    def initialize_required(key, options)
+      initialize_optional(key, options, nil) ||
+        raise(ArgumentError, "Missing required argument: #{key}")
+    end
+
+    def initialize_optional(key, options, default)
+      options[key] ||
+        options[key.to_s] ||
+        ENV["AMADEUS_#{key.to_s.upcase}"] ||
+        default
+    end
+
+    def initialize_logger(options)
+      options[:logger] || options['logger'] || Logger.new(STDOUT)
+    end
+  end
+end

--- a/lib/amadeus/version.rb
+++ b/lib/amadeus/version.rb
@@ -1,3 +1,3 @@
 module Amadeus
-  VERSION = "0.1.0"
+  VERSION = '0.1.0'.freeze
 end

--- a/spec/amadeus_spec.rb
+++ b/spec/amadeus_spec.rb
@@ -1,7 +1,0 @@
-require "spec_helper"
-
-RSpec.describe Amadeus do
-  it "has a version number" do
-    expect(Amadeus::VERSION).not_to be nil
-  end
-end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -1,0 +1,80 @@
+require 'spec_helper'
+
+RSpec.describe Amadeus::Client do
+  it 'should exist' do
+    expect(Amadeus::Client).not_to be nil
+  end
+
+  describe '.initialize' do
+    before do
+      @valid_params = {
+        api_key: '1234',
+        api_secret: '4546'
+      }
+    end
+
+    it 'should create a new client with direct variables' do
+      expect(Amadeus::Client.new(@valid_params)).to(
+        be_instance_of(Amadeus::Client)
+      )
+    end
+
+    it 'should create a new client with string-key variables' do
+      params = {
+        'api_key' => '1234',
+        'api_secret' => '4546'
+      }
+
+      expect(Amadeus::Client.new(params)).to(
+        be_instance_of(Amadeus::Client)
+      )
+    end
+
+    it 'should create a new client with environment variables' do
+      ENV['AMADEUS_API_KEY'] = '123'
+      ENV['AMADEUS_API_SECRET'] = '234'
+
+      expect(Amadeus::Client.new).to(
+        be_instance_of(Amadeus::Client)
+      )
+
+      ENV.delete('AMADEUS_API_KEY')
+      ENV.delete('AMADEUS_API_SECRET')
+    end
+
+    describe 'with missing parameters' do
+      %i[api_key api_secret].each do |key|
+        it "should refuse to create a new client without #{key}" do
+          @valid_params.delete(key)
+          expect{ Amadeus::Client.new(@valid_params) }.to(
+            raise_error(ArgumentError)
+          )
+        end
+      end
+    end
+
+    it 'should by default have a logger' do
+      amadeus = Amadeus::Client.new(@valid_params)
+      expect(amadeus.logger).to be_instance_of(Logger)
+      expect(amadeus.logger.level).to eq(Logger::WARN)
+    end
+
+    [:logger, 'logger'].each do |key|
+      it "should allow for setting a custom logger (#{key})" do
+        logger = Logger.new(STDOUT)
+        @valid_params[key] = logger
+        amadeus = Amadeus::Client.new(@valid_params)
+        expect(amadeus.logger).to equal(logger)
+        expect(amadeus.logger.level).to eq(Logger::WARN)
+      end
+    end
+
+    [:log_level, 'log_level'].each do |key|
+      it "should allow for setting a custom log level (#{key})" do
+        @valid_params[key] = Logger::FATAL
+        amadeus = Amadeus::Client.new(@valid_params)
+        expect(amadeus.logger.level).to eq(Logger::FATAL)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,10 @@
-require "bundler/setup"
-require "amadeus"
+require 'bundler/setup'
+require 'amadeus'
+require 'awesome_print'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = ".rspec_status"
+  config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -1,0 +1,12 @@
+require 'spec_helper'
+
+RSpec.describe Amadeus do
+  it 'should have a version' do
+    expect(Amadeus::VERSION).not_to be nil
+  end
+
+  it 'should have a version that matches the gemspec' do
+    gemspec = Gem::Specification.load('amadeus.gemspec')
+    expect(Amadeus::VERSION).to eq(gemspec.version.to_s)
+  end
+end


### PR DESCRIPTION
Adds an `Amadeus::Client` object that can take an API key, secret, and optionally a custom Logger and Log level.
