### PR TITLE
Update error formatting, default to silent errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ require 'logger'
 amadeus = Amadeus::Client.new(
   client_id: '...',
   client_secret: '...',
-  log_level: 'debug'
+  log_level: 'debug' # or "warn" or "silent", defaults to "silent"
 )
 ```
 

--- a/lib/amadeus/client.rb
+++ b/lib/amadeus/client.rb
@@ -63,8 +63,8 @@ module Amadeus
     #  the API
     # @option options [Object] :logger ('Logger') a `Logger`-compatible logger
     #  that accepts a debug call
-    # @option options [string] :log_level ('warn') if this client is running in
-    #  debug, warn, or silent mode
+    # @option options [string] :log_level ('silent') if this client is running
+    #  in debug, warn, or silent mode
     # @option options [string] :hostname ('production') the name of the server
     #  API calls are made to (`production` or `test`)
     # @option options [string] :custom_app_id (null) a custom App ID to be

--- a/lib/amadeus/client/validator.rb
+++ b/lib/amadeus/client/validator.rb
@@ -19,7 +19,7 @@ module Amadeus
       # @!visibility private
       def initialize_logger(options)
         @logger       = init_optional(:logger, options, Logger.new(STDOUT))
-        @log_level    = init_optional(:log_level, options, 'warn')
+        @log_level    = init_optional(:log_level, options, 'silent')
       end
 
       # Initializes the port, hostname, and use of SSL

--- a/spec/client/errors_spec.rb
+++ b/spec/client/errors_spec.rb
@@ -3,38 +3,78 @@
 require 'spec_helper'
 
 RSpec.describe Amadeus::ResponseError do
-  describe '.description' do
-    it 'should determine no description if no response is present' do
+  describe '.to_s' do
+    it 'should determine default value if no response is present' do
       error = Amadeus::NetworkError.new(nil)
-      expect(error.description).to be_nil
+      expect(error.to_s).to eq('[---]')
     end
 
-    it 'should determine no description if no data is present' do
+    it 'should determine default value if response has no status code' do
       http_response = double('HTTPResponse')
-      allow(http_response).to receive(:code).and_return(200)
+      response = Amadeus::Response.new(http_response, nil)
+      error = Amadeus::NetworkError.new(response)
+      expect(error.to_s).to eq('[---]')
+    end
+
+    it 'should return just the status code of no errors are in the response' do
+      http_response = double('HTTPResponse')
+      allow(http_response).to receive(:code).and_return(400)
       allow(http_response).to receive(:body).and_return('{}')
       allow(http_response).to receive(:[]).and_return('application/json')
 
-      response = Amadeus::Response.new(http_response, nil)
-      error = Amadeus::NetworkError.new(response)
-      expect(error.description).to be_nil
+      response = Amadeus::Response.new(http_response, nil).parse(nil)
+      error = Amadeus::ClientError.new(response)
+      expect(error.to_s).to eq('[400]')
     end
 
-    it 'should determine the description if errors are present' do
+    it 'should return a multiline response when multipel errors are present' do
       http_response = double('HTTPResponse')
-      allow(http_response).to receive(:code).and_return(200)
+      allow(http_response).to receive(:code).and_return(401)
       allow(http_response).to(
         receive(:body)
-          .and_return('{ "errors" : [ { "detail" : "error" }] }')
+          .and_return(%(
+            { "errors": [
+               {
+                 "status":400,
+                 "code":32171,
+                 "title":"MANDATORY DATA MISSING",
+                 "detail":"This field must be filled.",
+                 "source":{
+                   "parameter":"departureDate"
+                 }
+               },
+               {
+                 "status":400,
+                 "code":32171,
+                 "title":"MANDATORY DATA MISSING",
+                 "detail":"This field must be filled.",
+                 "source":{
+                   "parameter":"origin"
+                 }
+               },
+               {
+                 "status":400,
+                 "code":32171,
+                 "title":"MANDATORY DATA MISSING",
+                 "detail":"This field must be filled.",
+                 "source":{
+                   "parameter":"destination"
+                 }
+               }
+              ]}
+          ))
       )
       allow(http_response).to receive(:[]).and_return('application/json')
 
-      response = Amadeus::Response.new(http_response, nil).parse({})
+      response = Amadeus::Response.new(http_response, nil).parse(nil)
       error = Amadeus::NetworkError.new(response)
-      expect(error.description).to eq([{ 'detail' => 'error' }])
+      expect(error.to_s).to eq(%([401]
+[departureDate] This field must be filled.
+[origin] This field must be filled.
+[destination] This field must be filled.))
     end
 
-    it 'should determine the description if an error_description is present' do
+    it 'should return a single error if an error_description is present' do
       http_response = double('HTTPResponse')
       allow(http_response).to receive(:code).and_return(200)
       allow(http_response).to(
@@ -43,9 +83,9 @@ RSpec.describe Amadeus::ResponseError do
       )
       allow(http_response).to receive(:[]).and_return('application/json')
 
-      response = Amadeus::Response.new(http_response, nil).parse({})
+      response = Amadeus::Response.new(http_response, nil).parse(nil)
       error = Amadeus::NetworkError.new(response)
-      expect(error.description).to eq('error_description' => 'error')
+      expect(error.to_s).to eq("[200]\nerror")
     end
   end
 

--- a/spec/client/validator_spec.rb
+++ b/spec/client/validator_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Amadeus::Client::Validator do
     it 'should by default have a logger' do
       amadeus = Amadeus::Client.new(@valid_params)
       expect(amadeus.logger).to be_instance_of(Logger)
-      expect(amadeus.log_level).to eq('warn')
+      expect(amadeus.log_level).to eq('silent')
     end
 
     [:logger, 'logger'].each do |key|


### PR DESCRIPTION
Based on quick look at errors in other Ruby SDKs I've changed the errors as follows. See article:

https://betta.io/blog/2018/03/30/graceful-errors-in-ruby-sdks/

1. Remove `.description` attribute from `ResponseError`. All the information in here is available in the `.response` anyway.
2. Use `.to_s` to output better error descriptions when they are raised.
3. Change default log level to `"silent"`. Previously it was set to warn, which is not done by anyone else.

Here are some example of what errors now look like.

## NetworkError

```
Traceback (most recent call last):
	11: from test.rb:12:in `<main>'
	10: from /namespaces/shopping/flight_offers.rb:31:in `get'
	 9: from /client/http.rb:27:in `get'
	 8: from /client/http.rb:60:in `request'
	 7: from /client/access_token.rb:20:in `bearer_token'
	 6: from /client/access_token.rb:29:in `token'
	 5: from /client/access_token.rb:42:in `update_access_token'
	 4: from /client/access_token.rb:48:in `fetch_access_token'
	 3: from /client/http.rb:79:in `unauthenticated_request'
	 2: from /client/http.rb:97:in `execute'
	 1: from /client/http.rb:105:in `fetch'
/client/http.rb:114:in `rescue in fetch': [---] (Amadeus::NetworkError)
```

