### PR TITLE
Update to bundler 2.0.1, remove support of ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.2
 - 2.3
 - 2.4
 - 2.5

--- a/amadeus.gemspec
+++ b/amadeus.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2.0'
 
   spec.add_development_dependency 'awesome_print', '~> 1.8'
-  spec.add_development_dependency 'bundler', '~> 1.16'
+  spec.add_development_dependency 'bundler', '~> 2.0.1'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-rake', '~> 1.0'
   spec.add_development_dependency 'guard-yard', '~> 2.2'


### PR DESCRIPTION
After the release of bundler 2.0 (which has a dependency on RubyGems 3.0.0):

https://docs.travis-ci.com/user/languages/ruby/#bundler-20

- Remove the support for Ruby 2.2
- Upgrade bundler to v2.0.1