### PR TITLE
Add support for Ruby 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ rvm:
 - 2.3
 - 2.4
 - 2.5
+- 2.6
 - 2.5.0 # explicit branch used for deploying docs
 - ruby-head
 - jruby


### PR DESCRIPTION
Ruby 2.6 has been released on Dec 2018.
Adding the support/test fir ruby 2.6